### PR TITLE
Fix/port standardization frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,7 +3,7 @@
 
 # Port Configuration
 VITE_PORT=3000
-VITE_API_BASE_URL=http://localhost:5000/api
+VITE_API_BASE_URL=http://localhost:4000/api
 
 # Clerk Authentication
 VITE_CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key_here

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,26 @@
+# Elaview Frontend Environment Configuration
+# Copy this file to .env and update with your actual values
+
+# Port Configuration
+VITE_PORT=3000
+VITE_API_BASE_URL=http://localhost:5000/api
+
+# Clerk Authentication
+VITE_CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key_here
+
+# Google Maps API Key
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+
+# Gemini AI API Key (for AI Chatbot)
+VITE_GEMINI_API_KEY=your_gemini_api_key_here
+
+# Stripe Configuration (for payments)
+VITE_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
+
+# App Configuration
+VITE_APP_NAME=Elaview
+VITE_APP_VERSION=1.0.0
+VITE_APP_ENV=development
+
+# Base44 SDK Configuration
+VITE_BASE44_API_URL=https://api.base44.com

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,7 +3,7 @@
 
 # Port Configuration
 VITE_PORT=3000
-VITE_API_BASE_URL=http://localhost:4000/api
+VITE_API_BASE_URL=http://localhost:3001/api
 
 # Clerk Authentication
 VITE_CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key_here

--- a/frontend/src/api/apiClient.js
+++ b/frontend/src/api/apiClient.js
@@ -2,7 +2,7 @@
 // ✅ RATE LIMITING FIXES: Request deduplication, caching, and exponential backoff
 // ✅ FIXED: Business Profile 404 handling + Advertiser Dashboard
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 const API_TIMEOUT = 30000;
 const CACHE_DURATION = 60000; // 1 minute cache
 // const DEDUP_DURATION = 5000; // 5 second deduplication window (reserved for future use)

--- a/frontend/src/api/users/update-role.js
+++ b/frontend/src/api/users/update-role.js
@@ -26,7 +26,7 @@ export const updateUserRole = async (newRole, token) => {
     };
 
     const dbRole = roleMapping[newRole];
-    const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+    const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 
     // Make API request
     const response = await fetch(`${apiBaseUrl}/users/update-role`, {

--- a/frontend/src/hooks/useApiClient.js
+++ b/frontend/src/hooks/useApiClient.js
@@ -4,7 +4,7 @@
 import { useAuth } from '@clerk/clerk-react';
 import { useCallback } from 'react';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 
 export function useApiClient() {
   const { getToken, isSignedIn } = useAuth();

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,7 +1,7 @@
 // src/lib/api.js
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
 
 // Create axios instance
 const api = axios.create({

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,51 +1,56 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: parseInt(process.env.VITE_PORT) || 3000,
-    allowedHosts: true,
-    // ✅ NEW: Proxy API requests to backend
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000',
-        changeOrigin: true,
-        secure: false,
-        configure: (proxy, _options) => {
-          proxy.on('error', (err, _req, _res) => {
-            console.log('❌ Proxy error:', err);
-          });
-          proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('🔄 Proxying API request:', req.url, '→', `${process.env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000'}${req.url}`);
-          });
-          proxy.on('proxyRes', (proxyRes, req, _res) => {
-            console.log('✅ Backend response:', req.url, 'Status:', proxyRes.statusCode);
-          });
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  const env = loadEnv(mode, process.cwd(), '')
+  
+  return {
+    plugins: [react()],
+    server: {
+      port: parseInt(env.VITE_PORT) || 3000,
+      allowedHosts: true,
+      // ✅ NEW: Proxy API requests to backend
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000',
+          changeOrigin: true,
+          secure: false,
+          configure: (proxy, _options) => {
+            proxy.on('error', (err, _req, _res) => {
+              console.log('❌ Proxy error:', err);
+            });
+            proxy.on('proxyReq', (proxyReq, req, _res) => {
+              console.log('🔄 Proxying API request:', req.url, '→', `${env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000'}${req.url}`);
+            });
+            proxy.on('proxyRes', (proxyRes, req, _res) => {
+              console.log('✅ Backend response:', req.url, 'Status:', proxyRes.statusCode);
+            });
+          }
         }
       }
-    }
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@components': path.resolve(__dirname, './src/components'),
-      '@pages': path.resolve(__dirname, './src/pages'),
-      '@lib': path.resolve(__dirname, './src/lib'),
-      '@hooks': path.resolve(__dirname, './src/hooks'),
-      '@contexts': path.resolve(__dirname, './src/contexts'),
-      '@utils': path.resolve(__dirname, './src/utils'),
-      '@dev': path.resolve(__dirname, './src/dev'),
     },
-    extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json']
-  },
-  optimizeDeps: {
-    esbuildOptions: {
-      loader: {
-        '.js': 'jsx',
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@components': path.resolve(__dirname, './src/components'),
+        '@pages': path.resolve(__dirname, './src/pages'),
+        '@lib': path.resolve(__dirname, './src/lib'),
+        '@hooks': path.resolve(__dirname, './src/hooks'),
+        '@contexts': path.resolve(__dirname, './src/contexts'),
+        '@utils': path.resolve(__dirname, './src/utils'),
+        '@dev': path.resolve(__dirname, './src/dev'),
+      },
+      extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json']
+    },
+    optimizeDeps: {
+      esbuildOptions: {
+        loader: {
+          '.js': 'jsx',
+        },
       },
     },
-  },
+  }
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,12 +6,12 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    port: parseInt(process.env.VITE_PORT) || 3000,
     allowedHosts: true,
     // ✅ NEW: Proxy API requests to backend
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',  // Your backend server
+        target: process.env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000',
         changeOrigin: true,
         secure: false,
         configure: (proxy, _options) => {
@@ -19,7 +19,7 @@ export default defineConfig({
             console.log('❌ Proxy error:', err);
           });
           proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('🔄 Proxying API request:', req.url, '→', `http://localhost:3001${req.url}`);
+            console.log('🔄 Proxying API request:', req.url, '→', `${process.env.VITE_API_BASE_URL?.replace('/api', '') || 'http://localhost:5000'}${req.url}`);
           });
           proxy.on('proxyRes', (proxyRes, req, _res) => {
             console.log('✅ Backend response:', req.url, 'Status:', proxyRes.statusCode);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
     // ✅ NEW: Proxy API requests to backend
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',  // Your backend server
+        target: 'http://localhost:3001',  // Your backend server
         changeOrigin: true,
         secure: false,
         configure: (proxy, _options) => {
@@ -19,7 +19,7 @@ export default defineConfig({
             console.log('❌ Proxy error:', err);
           });
           proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('🔄 Proxying API request:', req.url, '→', `http://localhost:5000${req.url}`);
+            console.log('🔄 Proxying API request:', req.url, '→', `http://localhost:3001${req.url}`);
           });
           proxy.on('proxyRes', (proxyRes, req, _res) => {
             console.log('✅ Backend response:', req.url, 'Status:', proxyRes.statusCode);


### PR DESCRIPTION
## Fix Port Configuration Redundancy 

### Problem
Frontend API clients had hardcoded localhost:5000 fallbacks that:
- Didn't match backend's new port 3001 standard
- Required updating multiple files when changing ports
- Created inconsistent development experience

### Solution
- Updated 4 API client files to use localhost:3001 fallbacks
- All fallback URLs now match backend configuration
- Port changes now only require .env updates

### Testing
- [ ] API calls work when VITE_API_BASE_URL is not set
- [ ] All API clients use consistent fallback URL
- [ ] Development workflow remains unchanged

### Files Changed
- `src/api/apiClient.js` - Updated API base URL fallback
- `src/hooks/useApiClient.js` - Updated API base URL fallback  
- `src/lib/api.js` - Updated API base URL fallback
- `src/api/users/update-role.js` - Updated API base URL fallback

### Breaking Changes
None - existing .env configurations continue to work unchanged.