### PR TITLE
feat(filters): price slider, reactive histogram, and simplified space types

### DIFF
--- a/frontend/src/components/search/SearchResults.jsx
+++ b/frontend/src/components/search/SearchResults.jsx
@@ -325,16 +325,7 @@ const ResultCard = ({
         </div>
 
         {/* Favorite Button */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onToggleFavorite(item.id)}
-          className={`absolute top-4 right-4 h-8 w-8 p-0 backdrop-blur-sm rounded-full ${
-            isFavorite ? 'text-red-500 bg-white/90' : 'text-gray-500 bg-white/70 hover:bg-white/90'
-          }`}
-        >
-          <Heart className={`w-4 h-4 ${isFavorite ? 'fill-current' : ''}`} />
-        </Button>
+        {/* Favorite button removed */}
 
         {/* Price Tag */}
         <div className="absolute bottom-4 right-4">
@@ -461,15 +452,6 @@ const ResultListItem = ({
                     </div>
                   )}
                 </div>
-                
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onToggleFavorite(item.id)}
-                  className={`h-8 w-8 p-0 ${isFavorite ? 'text-red-500' : 'text-gray-500'}`}
-                >
-                  <Heart className={`w-4 h-4 ${isFavorite ? 'fill-current' : ''}`} />
-                </Button>
               </div>
             </div>
 

--- a/frontend/src/pages/browse/BrowsePage.jsx
+++ b/frontend/src/pages/browse/BrowsePage.jsx
@@ -35,7 +35,7 @@ import { useBusinessProfile, checkBusinessProfileRequired } from '../checkout/ho
 // ✅ Import utility functions
 import { getDistanceInKm } from './utils/distance';
 import { getPropertyCoords, getPropertyAddress, getPropertyName } from './utils/propertyHelpers';
-import { getNumericPrice } from './utils/areaHelpers';
+import { getNumericPrice } from './utils/areaHelpers'; // single import (removed accidental duplicate)
 import { applyPriceFilter, applySpaceTypeFilter, applyAudienceFilter, applyFeaturesFilter } from './utils/filterHelpers';
 
 // ✅ Import constants
@@ -119,7 +119,10 @@ export default function BrowsePage() {
     spaceType: 'all',
     availability: 'all',
     audience: 'all',
-    features: [],
+  features: [],
+  // Numeric slider bounds
+  priceMin: 0,
+  priceMax: 2000,
   });
   
   // UI state
@@ -352,6 +355,13 @@ export default function BrowsePage() {
     let filtered = allSpaces;
 
     filtered = applyPriceFilter(filtered, filters.priceRange);
+    // Apply numeric slider bounds if user narrowed the range
+    if ((filters.priceMin !== 0) || (filters.priceMax !== 2000)) {
+      filtered = filtered.filter(space => {
+        const p = space.baseRate || getNumericPrice(space);
+        return p >= filters.priceMin && p <= filters.priceMax;
+      });
+    }
     filtered = applySpaceTypeFilter(filtered, filters.spaceType);
     filtered = applyAudienceFilter(filtered, filters.audience);
     filtered = applyFeaturesFilter(filtered, filters.features);
@@ -661,6 +671,15 @@ export default function BrowsePage() {
     }));
   };
 
+  // Atomic numeric price range setter for slider
+  const setPriceRange = (min, max) => {
+    setFilters(prev => ({
+      ...prev,
+      priceMin: Math.max(0, Math.min(min, max)),
+      priceMax: Math.max(Math.max(0, min), max)
+    }));
+  };
+
   const toggleFeature = (feature) => {
     setFilters(prev => ({
       ...prev,
@@ -676,7 +695,9 @@ export default function BrowsePage() {
       spaceType: 'all',
       availability: 'all',
       audience: 'all',
-      features: [],
+  features: [],
+  priceMin: 0,
+  priceMax: 2000,
     });
   };
 
@@ -1011,6 +1032,7 @@ export default function BrowsePage() {
           toggleFeature={toggleFeature}
           clearFilters={clearFilters}
           filteredSpaces={filteredSpaces}
+          setPriceRange={setPriceRange}
           style={{ zIndex: Z_INDEX.MODAL_CONTENT }}
         />
 
@@ -1344,6 +1366,7 @@ export default function BrowsePage() {
         toggleFeature={toggleFeature}
         clearFilters={clearFilters}
         filteredSpaces={filteredSpaces}
+  setPriceRange={setPriceRange}
         style={{ zIndex: Z_INDEX.MODAL_CONTENT }}
       />
   

--- a/frontend/src/pages/browse/components/FiltersModal.jsx
+++ b/frontend/src/pages/browse/components/FiltersModal.jsx
@@ -89,7 +89,7 @@ export default function FiltersModal({
                 <div className="flex flex-col gap-3">
                   {/* Interactive histogram similar to Airbnb price filter */}
                   {priceHistogram && priceHistogram.length > 0 && (
-                    <div className="w-full h-20 flex items-end gap-1 px-1">
+                    <div className="w-full h-24 flex items-end gap-1 px-1 bg-gradient-to-t from-slate-50 to-transparent rounded-sm">
                       {(() => {
                         const maxCount = Math.max(...priceHistogram.map(b => b.count || 0), 1);
                         return priceHistogram.map((bin, idx) => {
@@ -104,8 +104,8 @@ export default function FiltersModal({
                                 const newMax = bin.max === Infinity ? 2000 : bin.max;
                                 setPriceRange(newMin, newMax);
                               }}
-                              className={`flex-1 rounded-sm cursor-pointer transition-colors duration-150 ${active ? 'bg-blue-500/80 hover:bg-blue-500' : 'bg-slate-300 hover:bg-slate-400'}`}
-                              style={{ height: `${Math.max(8, heightPct)}%` }}
+                              className={`flex-1 rounded-[3px] cursor-pointer transition-colors duration-150 hover:shadow-sm ${active ? 'bg-blue-500/80 hover:bg-blue-500 outline outline-1 outline-blue-500/40' : 'bg-slate-300 hover:bg-slate-400'} `}
+                              style={{ height: `${Math.max(10, heightPct)}%`, minHeight: '10%' }}
                             />
                           );
                         });
@@ -184,11 +184,10 @@ export default function FiltersModal({
                 <div className="flex flex-wrap gap-3">
                   {[
                     { id: 'all', label: 'All Types', icon: Building2 },
-                    { id: 'digital', label: 'Digital', icon: Lightning },
-                    { id: 'outdoor', label: 'Outdoor', icon: Eye },
-                    { id: 'retail', label: 'Retail', icon: Building2 },
-                    { id: 'transit', label: 'Transit', icon: Navigation },
-                    { id: 'indoor', label: 'Indoor', icon: Monitor }
+                    { id: 'retail', label: 'Window', icon: Building2 }, // storefront / window displays
+                    { id: 'outdoor', label: 'Exterior', icon: Eye }, // building exterior / outdoor
+                    { id: 'wall', label: 'Wall', icon: Monitor }, // wall graphics / wraps (custom category)
+                    { id: 'digital', label: 'Digital', icon: Lightning }
                   ].map(type => (
                     <button
                       key={type.id}

--- a/frontend/src/pages/browse/components/FiltersModal.jsx
+++ b/frontend/src/pages/browse/components/FiltersModal.jsx
@@ -231,32 +231,6 @@ export default function FiltersModal({
                   ))}
                 </div>
               </div>
-
-              {/* Features */}
-              <div>
-                <h3 className="label text-slate-800 mb-4">Features</h3>
-                <div className="flex flex-wrap gap-3">
-                  {[
-                    { id: 'verified', label: 'Verified Owner', icon: CheckCircle },
-                    { id: 'high_traffic', label: 'High Traffic', icon: TrendingUp },
-                    { id: 'premium', label: 'Premium Location', icon: Star },
-                    { id: 'digital', label: 'Digital Display', icon: Lightning }
-                  ].map(feature => (
-                    <button
-                      key={feature.id}
-                      className={`px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-all duration-200 ${
-                        filters.features.includes(feature.id) 
-                          ? 'bg-blue-500 text-white shadow-md hover:bg-blue-600' 
-                          : 'bg-slate-100 text-slate-700 border border-slate-200 hover:bg-slate-200 hover:border-slate-300'
-                      }`}
-                      onClick={() => toggleFeature(feature.id)}
-                    >
-                      <feature.icon className="w-4 h-4" />
-                      {feature.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
             </div>
 
             {/* Filter Actions */}

--- a/frontend/src/pages/browse/components/FiltersModal.jsx
+++ b/frontend/src/pages/browse/components/FiltersModal.jsx
@@ -184,9 +184,8 @@ export default function FiltersModal({
                 <div className="flex flex-wrap gap-3">
                   {[
                     { id: 'all', label: 'All Types', icon: Building2 },
-                    { id: 'retail', label: 'Window', icon: Building2 }, // storefront / window displays
-                    { id: 'outdoor', label: 'Exterior', icon: Eye }, // building exterior / outdoor
-                    { id: 'wall', label: 'Wall', icon: Monitor }, // wall graphics / wraps (custom category)
+                    { id: 'retail', label: 'Window', icon: Building2 },
+                    { id: 'exteriorwall', label: 'Exterior Wall', icon: Eye },
                     { id: 'digital', label: 'Digital', icon: Lightning }
                   ].map(type => (
                     <button

--- a/frontend/src/pages/browse/components/FiltersModal.jsx
+++ b/frontend/src/pages/browse/components/FiltersModal.jsx
@@ -220,11 +220,14 @@ export default function FiltersModal({
                 <span className="body-small text-slate-600">
                   {filteredSpaces.length} space{filteredSpaces.length !== 1 ? 's' : ''} found
                 </span>
-                <button 
+                <button
                   onClick={() => setShowFilters(false)}
-                  className="btn-primary"
+                  className="px-4 py-2.5 rounded-md text-[13px] font-semibold flex items-center gap-2 bg-blue-500 text-white shadow hover:shadow-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400/70 focus:ring-offset-1 transition"
                 >
-                  Show Results
+                  <span>Show Results</span>
+                  <span className="inline-flex items-center justify-center text-[9px] font-bold bg-white/20 px-1.5 py-0.5 rounded-full tracking-wide min-w-[24px]">
+                    {filteredSpaces.length}
+                  </span>
                 </button>
               </div>
             </div>

--- a/frontend/src/pages/browse/components/FiltersModal.jsx
+++ b/frontend/src/pages/browse/components/FiltersModal.jsx
@@ -205,32 +205,6 @@ export default function FiltersModal({
                   ))}
                 </div>
               </div>
-
-              {/* Target Audience */}
-              <div>
-                <h3 className="label text-slate-800 mb-4">Target Audience</h3>
-                <div className="flex flex-wrap gap-3">
-                  {[
-                    { id: 'all', label: 'Everyone', icon: Users },
-                    { id: 'families', label: 'Families', icon: Users },
-                    { id: 'professionals', label: 'Professionals', icon: Target },
-                    { id: 'commuters', label: 'Commuters', icon: Navigation }
-                  ].map(audience => (
-                    <button
-                      key={audience.id}
-                      className={`px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-all duration-200 ${
-                        filters.audience === audience.id 
-                          ? 'bg-blue-500 text-white shadow-md hover:bg-blue-600' 
-                          : 'bg-slate-100 text-slate-700 border border-slate-200 hover:bg-slate-200 hover:border-slate-300'
-                      }`}
-                      onClick={() => toggleFilter('audience', audience.id)}
-                    >
-                      <audience.icon className="w-4 h-4" />
-                      {audience.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
             </div>
 
             {/* Filter Actions */}

--- a/frontend/src/pages/browse/components/SpaceCard.jsx
+++ b/frontend/src/pages/browse/components/SpaceCard.jsx
@@ -69,18 +69,7 @@ export default function SpaceCard({
             </div>
 
             <div className="absolute top-3 right-3 flex gap-2">
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleSavedSpace(space.id);
-                }}
-                className="p-2 bg-white/90 hover:bg-white rounded-full transition-colors shadow-sm backdrop-blur-sm"
-                style={{ border: '1px solid #E5E7EB' }}
-              >
-                <Heart className={`w-4 h-4 ${
-                  savedSpaces.has(space.id) ? 'fill-red-500 text-red-500' : 'text-slate-600'
-                }`} />
-              </button>
+              {/* Favorite button removed  */}
               
               {/* Quick Add to Cart Button */}
               <button

--- a/frontend/src/pages/browse/components/SpaceDetailsModal.jsx
+++ b/frontend/src/pages/browse/components/SpaceDetailsModal.jsx
@@ -311,14 +311,7 @@ export default function SpaceDetailsModal({
             <div className="absolute inset-0 bg-gradient-to-t from-slate-900/80 to-transparent" />
             
             <div className="absolute top-4 right-4 flex gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsSaved(!isSaved)}
-                className="bg-white/90 backdrop-blur-sm hover:bg-white"
-              >
-                <Heart className={`w-4 h-4 ${isSaved ? 'fill-red-500 text-red-500' : 'text-slate-600'}`} />
-              </Button>
+              {/* Favorite button removed */}
               <Button
                 variant="ghost"
                 size="sm"

--- a/frontend/src/pages/browse/utils/filterHelpers.js
+++ b/frontend/src/pages/browse/utils/filterHelpers.js
@@ -3,7 +3,7 @@
 
 import { getNumericPrice } from './areaHelpers';
 import { getBusinessInsights, getTrustIndicators } from './businessInsights';
-import { SPACE_TYPE_CATEGORIES } from './mapConstants';
+import { SPACE_TYPE_CATEGORIES, SPACE_TYPE_CATEGORIES_WALL_EXT } from './mapConstants';
 
 /**
  * Apply price range filter to spaces
@@ -44,16 +44,13 @@ export const applyPriceFilter = (spaces, priceRange) => {
 export const applySpaceTypeFilter = (spaces, spaceType) => {
   if (spaceType === 'all') return spaces;
   
+  const combined = { ...SPACE_TYPE_CATEGORIES, ...SPACE_TYPE_CATEGORIES_WALL_EXT };
   return spaces.filter(space => {
     const type = space.type?.toLowerCase() || '';
-    
-    // Check if space type matches any of the category types
-    const categoryTypes = SPACE_TYPE_CATEGORIES[spaceType];
+    const categoryTypes = combined[spaceType];
     if (!categoryTypes) return false;
-    
-    return categoryTypes.some(categoryType => 
-      type.includes(categoryType.toLowerCase()) || 
-      type === categoryType.toLowerCase()
+    return categoryTypes.some(categoryType =>
+      type.includes(categoryType.toLowerCase()) || type === categoryType.toLowerCase()
     );
   });
 };

--- a/frontend/src/pages/browse/utils/filterHelpers.js
+++ b/frontend/src/pages/browse/utils/filterHelpers.js
@@ -3,7 +3,7 @@
 
 import { getNumericPrice } from './areaHelpers';
 import { getBusinessInsights, getTrustIndicators } from './businessInsights';
-import { SPACE_TYPE_CATEGORIES, SPACE_TYPE_CATEGORIES_WALL_EXT } from './mapConstants';
+import { SPACE_TYPE_CATEGORIES, SPACE_TYPE_CATEGORIES_WALL_EXT, SPACE_TYPE_CATEGORIES_COMBINED } from './mapConstants';
 
 /**
  * Apply price range filter to spaces
@@ -44,7 +44,7 @@ export const applyPriceFilter = (spaces, priceRange) => {
 export const applySpaceTypeFilter = (spaces, spaceType) => {
   if (spaceType === 'all') return spaces;
   
-  const combined = { ...SPACE_TYPE_CATEGORIES, ...SPACE_TYPE_CATEGORIES_WALL_EXT };
+  const combined = { ...SPACE_TYPE_CATEGORIES, ...SPACE_TYPE_CATEGORIES_WALL_EXT, ...SPACE_TYPE_CATEGORIES_COMBINED };
   return spaces.filter(space => {
     const type = space.type?.toLowerCase() || '';
     const categoryTypes = combined[spaceType];

--- a/frontend/src/pages/browse/utils/mapConstants.js
+++ b/frontend/src/pages/browse/utils/mapConstants.js
@@ -114,6 +114,10 @@ export const SPACE_TYPE_CATEGORIES = {
 export const SPACE_TYPE_CATEGORIES_WALL_EXT = {
   wall: ['wall_graphic', 'building_wrap']
 };
+// Combined exterior + wall category for simplified UI selection
+export const SPACE_TYPE_CATEGORIES_COMBINED = {
+  exteriorwall: ['building_exterior', 'wall_graphic', 'building_wrap']
+};
 
 // ✅ PRESERVED: Price ranges for ILS currency (Kfar Kama pricing)
 export const PRICE_RANGE_OPTIONS = [

--- a/frontend/src/pages/browse/utils/mapConstants.js
+++ b/frontend/src/pages/browse/utils/mapConstants.js
@@ -110,6 +110,10 @@ export const SPACE_TYPE_CATEGORIES = {
   transit: ['bus_shelter', 'platform_display', 'transit_station', 'parking_totem'],
   indoor: ['wall_graphic', 'floor_graphic', 'lobby_display', 'elevator_display', 'other']
 };
+// Minimal custom subset category for wall-specific filtering (requested UI subset)
+export const SPACE_TYPE_CATEGORIES_WALL_EXT = {
+  wall: ['wall_graphic', 'building_wrap']
+};
 
 // ✅ PRESERVED: Price ranges for ILS currency (Kfar Kama pricing)
 export const PRICE_RANGE_OPTIONS = [


### PR DESCRIPTION
Price filter
Replaced fixed ranges with dual range slider (0–2000) and enlarged min/max inputs (no spinners, allow empty during edit).
Updated accent color to app blue.
Price histogram
Added Airbnb‑style histogram; reactive to Space Type and Audience.
Uses getNumericPrice for accurate daily values (fixes low-price bins).
Bars clickable to set range.
Filters UI cleanup
Removed “Features” and “Target Audience” sections from modal UI.
Restyled “Show Results” button to match filter chips and slightly reduced size.
Space Type simplification
Now only: All, Window (retail), Exterior Wall (exterior + wall), Digital.
Added combined category mapping for filtering logic.
Misc
Kept previous favorites removal.
General polish and consistency.
